### PR TITLE
修复 本地AI Url 匹配和本地AI参与的 Bug

### DIFF
--- a/BotzoneLocalRunner/LocalMatch.cs
+++ b/BotzoneLocalRunner/LocalMatch.cs
@@ -136,7 +136,7 @@ namespace BotzoneLocalRunner
 				"<!-- INJECT_FINISHED_MATCH_LOGS_HERE -->",
 				$@"
 <script>
-	playerSlotID = {Configuration.First(conf => conf.Type == PlayerType.LocalHuman)?.SlotID ?? -1};
+	playerSlotID = {Configuration.FirstOrDefault(conf => conf.Type == PlayerType.LocalHuman)?.SlotID ?? -1};
 </script>
 ");
 			Browser.Load(BotzoneProtocol.Credentials.BotzoneLocalMatchURL(Configuration.Game.Name));

--- a/BotzoneLocalRunner/StringResources.Designer.cs
+++ b/BotzoneLocalRunner/StringResources.Designer.cs
@@ -88,7 +88,7 @@ namespace BotzoneLocalRunner {
         }
         
         /// <summary>
-        ///   查找类似 ([^\.]*\.botzone\.(org|org\.cn))/api/([0-9a-f]+)/([^/]+) 的本地化字符串。
+        ///   查找类似 ([^\.]*botzone\.(org|org\.cn))/api/([0-9a-f]+)/([^/]+) 的本地化字符串。
         /// </summary>
         public static string BOTZONE_LOCALAI_URL_REGEX {
             get {

--- a/BotzoneLocalRunner/StringResources.resx
+++ b/BotzoneLocalRunner/StringResources.resx
@@ -127,7 +127,7 @@
     <value>&lt;在此粘贴Botzone本地AI的URL（点击Botzone头像菜单查看）&gt;</value>
   </data>
   <data name="BOTZONE_LOCALAI_URL_REGEX" xml:space="preserve">
-    <value>([^\.]*\.botzone\.(org|org\.cn))/api/([0-9a-f]+)/([^/]+)</value>
+    <value>([^\.]*botzone\.(org|org\.cn))/api/([0-9a-f]+)/([^/]+)</value>
   </data>
   <data name="BOTZONE_MATCH" xml:space="preserve">
     <value>这是一场 Botzone 评测的对局</value>


### PR DESCRIPTION
Bugs:
1.  以 https://botzone.org/api 开头的 URL 正则匹配失败
2.  没有人类玩家参与的对局无法启动（错误信息：序列中没有匹配元素）